### PR TITLE
Fix regex pattern in configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
         "element-plus-doc.website.chinese": {
           "format": "URI",
           "type": "string",
-          "pattern": "^https?://([\\w-]+\\.)+[\\w-]+(/[\\w-./]*)?/$",
+          "pattern": "^https?:\/\/([\\w\\-]+\\.)+[\\w\\-]+(\/[\\w\\-.\/]*)?\/$",
           "default": "https://element-plus.org/zh-CN/",
           "markdownDescription": "%contributes.properties.website.chinese.description%"
         },
         "element-plus-doc.website.english": {
           "type": "string",
           "format": "URI",
-          "pattern": "^https?://([\\w-]+\\.)+[\\w-]+(/[\\w-./]*)?/$",
+          "pattern": "^https?:\/\/([\\w\\-]+\\.)+[\\w\\-]+(\/[\\w\\-.\/]*)?\/$",
           "default": "https://element-plus.org/en-US/",
           "markdownDescription": "%contributes.properties.website.english.description%"
         }


### PR DESCRIPTION
1.83.0版的vscode在加载设置时遇到了这个正则表达式，解析错误，导致无法加载所有扩展的设置。
#7 
```
^https?://([\\w-]+\\.)+[\\w-]+(/[\\w-./]*)?/$
```
错误：
```
ERR Invalid regular expression: /^https?://([\w-]+\.)+[\w-]+(/[\w-./]*)?/$/u: Invalid character class: SyntaxError: Invalid regular expression: /^https?://([\w-]+\.)+[\w-]+(/[\w-./]*)?/$/u: Invalid character class
```
转义了一些字符。
现在在vscode 1.83.0可以正常加载。